### PR TITLE
Pin the axiom sets of the isqrt theorems and definitions

### DIFF
--- a/proofs/isqrt/Isqrt/Definitions/IsqrtRecursive.lean
+++ b/proofs/isqrt/Isqrt/Definitions/IsqrtRecursive.lean
@@ -56,7 +56,7 @@ def nsqrtRecursive (n c : Int) : PyExcept Int := do
     let a ← nsqrtRecursive (← n >> 2 * k + 2) (c / 2)
     return (← a << k) + (← (← n >> k + 2) // a)
 termination_by c.toNat
-decreasing_by grind only
+decreasing_by omega
 
 /-- Return the integer part of the square root of the input. -/
 def isqrtRecursive (n : Int) : PyExcept Int := do

--- a/proofs/isqrt/Isqrt/Tests.lean
+++ b/proofs/isqrt/Isqrt/Tests.lean
@@ -1,10 +1,11 @@
 module
 
+import Isqrt.Tests.Axioms
 import Isqrt.Tests.IsqrtIterative
 import Isqrt.Tests.IsqrtRecursive
 import Isqrt.Tests.PythonPrimitives
 
 /-!
-Aggregator module for the `#guard`-based sanity checks: the Python primitives and
-the two `isqrt` translations.
+Aggregator module for the build-time checks: the Python primitives, the two `isqrt`
+translations, and the pinned axiom sets.
 -/

--- a/proofs/isqrt/Isqrt/Tests/Axioms.lean
+++ b/proofs/isqrt/Isqrt/Tests/Axioms.lean
@@ -1,0 +1,56 @@
+module
+
+meta import Isqrt.Proofs.IterativeCorrectness
+meta import Isqrt.Proofs.RecursiveCorrectness
+
+/-!
+The axioms the correctness theorems and the definitions they are about rest on, pinned.
+
+`lake build --wfail` already rejects an incomplete proof, since `sorry` emits a warning. It does
+not reject an axiom introduced deliberately, and nothing else records what the theorems depend
+on, so each one's axiom set is asserted here: `propext`, `Classical.choice` and `Quot.sound` are
+Lean's own three, and any addition fails the build.
+
+Each theorem is checked separately rather than relying on one to cover the other transitively,
+so that a change to one proof cannot quietly narrow what is checked.
+
+The three definitions are pinned as well, and they are where the sets differ. `isqrtIterative`
+needs `propext` alone — it reaches even that only because `ForIn` is derived from `ForIn'`, whose
+membership invariant is a propositional equality it never uses. The two recursive definitions add
+`Quot.sound` as the price of well-founded recursion, which equation compilation pays whether or
+not the recursion is hard to justify. Neither needs `Classical.choice`: the termination proof is
+`omega`, and a tactic's proof term is part of the definition, so a tactic that reasons
+classically would show up here.
+-/
+
+/--
+info: 'isqrtIterative' depends on axioms: [propext]
+-/
+#guard_msgs (whitespace := lax) in
+#print axioms isqrtIterative
+
+/--
+info: 'nsqrtRecursive' depends on axioms: [propext, Quot.sound]
+-/
+#guard_msgs (whitespace := lax) in
+#print axioms nsqrtRecursive
+
+/--
+info: 'isqrtRecursive' depends on axioms: [propext, Quot.sound]
+-/
+#guard_msgs (whitespace := lax) in
+#print axioms isqrtRecursive
+
+/--
+info: 'isCorrectIsqrt_isqrtIterative' depends on axioms:
+  [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs (whitespace := lax) in
+#print axioms isCorrectIsqrt_isqrtIterative
+
+/--
+info: 'isCorrectIsqrt_isqrtRecursive' depends on axioms:
+  [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs (whitespace := lax) in
+#print axioms isCorrectIsqrt_isqrtRecursive

--- a/proofs/isqrt/README.md
+++ b/proofs/isqrt/README.md
@@ -69,9 +69,10 @@ The Lean source code is organised into three subdirectories of [`Isqrt`](Isqrt):
   those statements.
 - [`Isqrt/Proofs`](Isqrt/Proofs) contains proofs of the correctness statements, along
   with supporting lemmas.
-- [`Isqrt/Tests`](Isqrt/Tests) contains direct tests of the two `isqrt` implementations
-  and supporting definitions using Lean's `#guard` command, passing in inputs and
-  checking that the outputs are as expected.
+- [`Isqrt/Tests`](Isqrt/Tests) contains the build-time checks: direct tests of the two
+  `isqrt` implementations and supporting definitions using Lean's `#guard` command,
+  passing in inputs and checking that the outputs are as expected, plus the pinned axiom
+  sets in [`Isqrt/Tests/Axioms.lean`](Isqrt/Tests/Axioms.lean).
 
 In addition to the files under [`Isqrt`](Isqrt), there are three root files:
 
@@ -114,6 +115,13 @@ Lean was able to mechanically check every step of the proofs, and that the proof
 correct. The stronger `lake build --wfail` turns warnings into errors. Notably, `lake
 build` will still pass (with warnings) if there are incomplete proofs, marked by a
 `sorry` placeholder in Lean. `lake build --wfail` will fail in the presence of `sorry`s.
+
+An incomplete proof isn't the only way a theorem can be hollow: an axiom asserted
+outright produces no warning at all. So the build also pins the axioms that each
+correctness theorem and each definition depends on, in
+[`Isqrt/Tests/Axioms.lean`](Isqrt/Tests/Axioms.lean), which is where those sets are
+recorded and explained. Any change to one fails the build, so this is checked on every
+run rather than being something a reader has to think to verify.
 
 ## Running the algorithm
 
@@ -161,7 +169,8 @@ needs to have confidence in:
   correctness statement. That proof lives right at the bottom of
   [`Isqrt.Proofs.IterativeCorrectness`](Isqrt/Proofs/IterativeCorrectness.lean). The
   statement is simply: `theorem isCorrectIsqrt_isqrtIterative : isCorrectIsqrt
-  isqrtIterative := ...`
+  isqrtIterative := ...` That it is proved rather than asserted needn't be taken on trust
+  either: its axiom set is [pinned by the build](#building-the-project).
 - The Lean toolchain itself, including the compiler and standard library. It's
   conceivable (but highly unlikely) that Lean itself has bugs that mean that it reports
   validity of a proof that is actually invalid.


### PR DESCRIPTION
Records what the isqrt proofs actually rest on, and stops it drifting. `lake build --wfail` rejects an incomplete proof, since `sorry` emits a warning, but an axiom asserted outright emits nothing — and nothing in the project recorded the dependency either way. `Isqrt/Tests/Axioms.lean` now asserts each set with `#guard_msgs` over `#print axioms`, so any change fails the build.

Two changes, and the second is why the first is shaped as it is.

## The pins

Five constants: both correctness theorems, and the three definitions they are about. Measured on Lean 4.32.1:

| constant | axioms |
| --- | --- |
| `isqrtIterative` | `propext` |
| `nsqrtRecursive`, `isqrtRecursive` | `propext`, `Quot.sound` |
| `isCorrectIsqrt_isqrtIterative` | `propext`, `Classical.choice`, `Quot.sound` |
| `isCorrectIsqrt_isqrtRecursive` | `propext`, `Classical.choice`, `Quot.sound` |

The definitions are the interesting rows, and `Isqrt/Tests/Axioms.lean` explains them. `isqrtIterative` reaches `propext` only because `ForIn` is derived from `ForIn'`, whose membership invariant is a propositional equality it never uses. The recursive pair adds `Quot.sound`, which equation compilation charges for well-founded recursion whether or not the recursion is hard to justify.

## `decreasing_by grind only` → `decreasing_by omega`

Same goal, closed by a tactic whose proof term is not classical. A tactic's proof term is part of the definition, so `Classical.choice` was there as the residue of *how termination was proved*, not of anything the algorithm does — and both recursive definitions drop it.

Pinning the definitions is what makes that visible, which is the argument for going past a theorems-only guard. Measured both ways, **the two theorems depend on all three axioms either way**: they reach `Classical.choice` on their own account, not through the definitions. So a guard over theorems alone would have recorded nothing about this swap, and would stay silent if a definition turned classical later — a `for` becoming a `while`, say, or a `partial def` appearing.

## Verification

- `lake build --wfail`, `lake lint` and `lake exe isqrt 1729` → `41`, all clean.
- **The pins bite, tested two ways.** Putting `grind only` back fails the build on exactly the `nsqrtRecursive` and `isqrtRecursive` pins, naming `Classical.choice` in the diff — so the swap is genuinely locked in rather than merely done. And over-claiming `isqrtIterative` as `[propext, Quot.sound]` also fails, so it is an exact-set check, not a subset check.

## On the README

Three short additions: the file in the directory listing, a paragraph under Building the project on the gap `--wfail` leaves, and a clause in the trust section noting that a theorem being proved rather than asserted is itself checked.

It deliberately does not restate the sets. They shift whenever a definition is refactored — that being the point of pinning them — and the build checks the file where it cannot check the prose. `Isqrt/Tests/Axioms.lean` is the single record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
